### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Model Context Protocol (MCP) is a technology that allows AI assistants like Clau
 - AI can help search, summarize, and analyze your Confluence documentation
 - Keeps sensitive information secure (the AI only sees what you share)
 
+<a href="https://glama.ai/mcp/servers/@aashari/mcp-server-atlassian-confluence">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@aashari/mcp-server-atlassian-confluence/badge" alt="Atlassian Confluence Server MCP server" />
+</a>
+
 This MCP server connects Claude, Cursor, or other compatible AI assistants with your Confluence instance, allowing them to search content, list spaces and pages, and access detailed documentation.
 
 ## Quick Start Guide


### PR DESCRIPTION
This PR adds a badge for the [Atlassian Confluence MCP Server](https://glama.ai/mcp/servers/@aashari/mcp-server-atlassian-confluence) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@aashari/mcp-server-atlassian-confluence">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@aashari/mcp-server-atlassian-confluence/badge" alt="Atlassian Confluence Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.